### PR TITLE
Unplug the unit from the transfer log.

### DIFF
--- a/api/cases/routes.js
+++ b/api/cases/routes.js
@@ -362,7 +362,6 @@ module.exports = (server) =>{
                 tags: ['api', 'cases.transfers'],
                 pre: [
                     CheckRoleView,
-                    CheckCredentialUnitIsExist,
                 ]
             },
             handler: handlers.GetCaseTransfers


### PR DESCRIPTION
## Overview
1. [route::prerequesites] Unplug check in unit from the transfer log.