### PR TITLE
leftover joi validation in additional field

### DIFF
--- a/api/close_contact/validations/input.js
+++ b/api/close_contact/validations/input.js
@@ -59,6 +59,7 @@ const RequestPayload = {
       relationship: Joi.string().required(),
       relationship_other: Joi.string().allow('', null),
       activity: Joi.array().allow('', null),
+      activity_other: Joi.string().allow('', null),
       emergency_contact_name: Joi.string().required(),
       emergency_contact_phone: Joi.string().required(),
       emergency_contact_relationship: Joi.string().allow('', null),
@@ -85,7 +86,7 @@ const RequestPayload = {
       officer_is_contact: Joi.boolean(),
       officer_protection_tools: Joi.array(),
       is_reported: Joi.boolean(),
-      latest_history: historyPayload 
+      latest_history: historyPayload
   }),
   options: validateOptions.options,
   failAction: validateOptions.failAction


### PR DESCRIPTION
## leftover joi validation in additional field 'activity_other'

_** This close contact module might be deleted or deprecated soon if revamp already released_

ref: https://github.com/jabardigitalservice/pikobar-pelaporan-backend/commit/b749dbfa669df2686eb89bce5c603324b1137938#diff-54b39f7bc352cc6bc5bfeda3db960228