### PR TITLE
Fix/add handler sofdeletes history

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -8,6 +8,8 @@ const register = (server, options, next) => {
     //console.log('RESPONSE_HEADER:', request.headers);
     //console.log('SERVER:', server.registrations);
     if (response.isBoom) {
+    console.log('RESPONSE :', response);
+
       Sentry.captureException(response)
 
       const reformated = {}

--- a/api/index.js
+++ b/api/index.js
@@ -8,8 +8,6 @@ const register = (server, options, next) => {
     //console.log('RESPONSE_HEADER:', request.headers);
     //console.log('SERVER:', server.registrations);
     if (response.isBoom) {
-    console.log('RESPONSE :', response);
-
       Sentry.captureException(response)
 
       const reformated = {}

--- a/services/histories.js
+++ b/services/histories.js
@@ -268,18 +268,13 @@ async function deleteHistoryById (id, author, callback) {
   try {
     const historyToDelete = await History.findById(id)
 
-    const histories = await History
-      .find({case: ObjectId(historyToDelete.case)})
-      .sort({ createdAt: 'desc'})
+    const histories = await History.find({case: ObjectId(historyToDelete.case)}).sort({ createdAt: 'desc'})
 
     if (histories.length <= 1) {
       throw new Error("Riwayat kasus hanya ada satu, tidak dapat dihapus!")
     }
 
-    const result = await History.updateOne(
-      { _id: ObjectId(id) },
-      { $set: Helper.deletedSave({}, author) },
-    )
+    const result = await History.updateOne({ _id: ObjectId(id) }, { $set: Helper.deletedSave({}, author) })
 
 
     // update if deleted history is a last history of case

--- a/services/histories.js
+++ b/services/histories.js
@@ -263,14 +263,39 @@ const listHistoryExport = async (query, user, callback) => {
   }
 }
 
-// soft delete
+// soft delete (dont suudzon / its never destroy any document) (fitur baru ada di sprint 9)
 async function deleteHistoryById (id, author, callback) {
   try {
-    const payload = Helper.deletedSave({}, author)
+    const historyToDelete = await History.findById(id)
+
+    const histories = await History
+      .find({case: ObjectId(historyToDelete.case)})
+      .sort({ createdAt: 'desc'})
+
+    if (histories.length <= 1) {
+      throw new Error("Riwayat kasus hanya ada satu, tidak dapat dihapus!")
+    }
+
     const result = await History.updateOne(
       { _id: ObjectId(id) },
-      { $set: payload },
+      { $set: Helper.deletedSave({}, author) },
     )
+
+
+    // update if deleted history is a last history of case
+    if (historyToDelete._id.toString() == histories[0]._id.toString()) {
+      histories.shift()
+      await Case.updateOne(
+        { _id: ObjectId(historyToDelete.case) },
+        { $set: {
+            status: histories[0].status,
+            final_result: histories[0].final_result,
+            last_date_status_patient: histories[0].last_date_status_patient,
+            last_history: ObjectId(histories[0]._id),
+        } },
+      )
+    }
+
     return callback(null, result)
   } catch (e) {
     return callback(e, null)


### PR DESCRIPTION
## Overview

1. commit ini untuk bertujuan untuk menghandle jika delete_status='deleted' adalah riwayat terakhir, 
maka riwayat terakhir akan disesuaikan dengan riwayat terbaru,
dan jika riwayat hanya satu maka tidak bisa dihapus :D

note:
ini tidak ada kaitannya dengan missing last_history ya 
**fitur ini beru ada sejak sprint 9**, di script ini hanya merubah delete_status='deleted' menggunakan fungsi `updateOne`
