### PR TITLE
[Production] improve inspection_support sheet getter

### DIFF
--- a/helpers/cases/sheet/getters/case.getters.js
+++ b/helpers/cases/sheet/getters/case.getters.js
@@ -175,7 +175,7 @@ getters.getInspectionSupport = (d) => {
     get_specimens_to: getSpecimenTo(d),
     inspection_result: getInspectionResult(d),
   }
-  return [ inspection_support ]
+  return inspection_support.inspection_type ? [ inspection_support ] : []
 }
 
 getters.getTravelingHistoryBeforeSick14Days = (d) => {


### PR DESCRIPTION
## Overview
1. Only added `inspection_support` object if `inspection_type` is valid